### PR TITLE
Account for edge cases in inclusion regex

### DIFF
--- a/fetch.py
+++ b/fetch.py
@@ -21,7 +21,7 @@ REGEX_CROM_RATE_LIMIT = re.compile(r"(?:in|for) (\d+) seconds?")
 REGEX_WIKIDOT_URL = re.compile(r'^https?://([\w\-]+)\.wikidot\.com/(.+)$')
 REGEX_MODULE_CSS = re.compile(r'\[\[module +css\]\]\n(.+?)\n\[\[/module\]\]', re.IGNORECASE | re.DOTALL)
 REGEX_INLINE_CSS = re.compile(r'style="(.+?)"[^\]]*?\]\]', re.MULTILINE | re.IGNORECASE)
-REGEX_INCLUDES = re.compile(r'\[\[include +([a-z0-9:\-_]+?)(?: |\]\])', re.MULTILINE | re.IGNORECASE)
+REGEX_INCLUDES = re.compile(r'^\[\[include[\s\n]+((?::[a-z0-9\-.]+:[\s\n]?)?[a-z0-9:\-.]+)', re.MULTILINE | re.IGNORECASE)
 REGEX_CLASSES = re.compile(r'class="([^\]]+?)"', re.MULTILINE | re.IGNORECASE)
 
 CROM_ENDPOINT = "https://api.crom.avn.sh/graphql"


### PR DESCRIPTION
The regex for inclusions is missing the following edge cases:

* `[[include page\n` - commonly used for components with multi-line parameters
* `[[include \n page]]` - not used currently as far as I can tell, but is valid
* `[[include :site: page]]` - used by one or two popular components; whitespace between site and page can be a single space or newline but only one
* `[[include :site.wikidot.com:page]]` - equivalent to `[[include :site:page]]`

70242 inclusions before this PR, 87040 afterwards (+16798) including 113 components that were otherwise unaccounted for

<details><summary><b>113 components</b></summary>
Listed in descending order of number of pages that include them

```sql
select source, count(distinct page_url) as page_count from extracts where extract_type="include" group by source order by page_count desc;
```

(I have made no attempt to deduplicate them)

| Included page | Pages |
| --- | --- |
| :scp-wiki:component:earthworm                     | 509 |
| component:info-ayers                              | 313 |
| :scp-wiki:component:classified-bar-woed           | 274 |
| :scp-wiki:component:interwiki-style               | 146 |
| component:earthworm                               | 112 |
| component:cd-ver2                                 | 59  |
| :scp-wiki:component:audio-player-woed-source      | 59  |
| :scp-wiki:component:acs-peppo-split               | 48  |
| :scp-wiki:component:flops-header                  | 42  |
| :scp-wiki:component:acs-hybrid-text-bar-source    | 40  |
| component:object-warning-box-source               | 38  |
| :scp-wiki:component:carousel                      | 34  |
| :snippets:image                                   | 22  |
| :scp-wiki: theme:calibri-logos                    | 22  |
| component:acs-peppo-split                         | 21  |
| theme:xmas                                        | 20  |
| :scp-wiki:component:acs-peppo-lite                | 18  |
| :scp-wiki:component:void-post                     | 16  |
| :scp-wiki:component:pages                         | 15  |
| :scp-wiki:component:object-class-bar-source       | 15  |
| component:acs-peppo-lite                          | 14  |
| :scp-wiki:component:s7-apcs                       | 14  |
| :snippets:bs-image                                | 13  |
| component:classified-bar-woed                     | 11  |
| component:author-page-collab                      | 10  |
| component:object-class-bar-source                 | 9   |
| component:classified-decoration                   | 9   |
| component:audio-player-woed-source                | 5   |
| :scp-wiki:component:passcode                      | 5   |
| :scp-wiki:component:mapping-source                | 5   |
| theme:minimal                                     | 3   |
| component:advanced-information-methodology        | 3   |
| :topia:cqb:carousel                               | 3   |
| :scpvnsandbox2:component:license-box              | 3   |
| :scp-wiki:component:scp-hover-box-structure       | 3   |
| :scp-wiki:component:acs-horm-lite-source          | 3   |
| :scp-wiki: component:object-warning-box-source    | 3   |
| :fes-ryuukatetu:include-list:radar-chart-6        | 3   |
| theme:spidersfalling                              | 2   |
| fragment:lapis-cards                              | 2   |
| component:scp-hover-box-structure                 | 2   |
| component:oct-r2                                  | 2   |
| component:image                                   | 2   |
| :scp.avn.sh:component:aers:classification-stuff   | 2   |
| :scp-wiki:fragment:facilities-map                 | 2   |
| :scp-wiki:component:void-post-source              | 2   |
| :scp-wiki:component:tz                            | 2   |
| :scp-wiki:component:svgheader                     | 2   |
| :scp-wiki:component:license-box-backend           | 2   |
| :scp-wiki:component:floppy-disruption-bar         | 2   |
| :scp-sandbox-3:component:finn-the-falcon          | 2   |
| :scp-sandbox-3:component:anomaly-class-bar-source | 2   |
| :scp-sandbox-3:component:acs-fork                 | 2   |
| :scp-sandbox-3.wikidot.com:more-by-othello        | 2   |
| fragment:yurtbox                                  | 1   |
| fragment:undervegas-card                          | 1   |
| fragment:task-forces-complete-list-licensebox     | 1   |
| fragment:task-forces-complete-list-images         | 1   |
| fragment:tactical-theology-history-box-start      | 1   |
| fragment:tactical-theology-box-scp                | 1   |
| fragment:tactical-theology-box-other              | 1   |
| fragment:table-filter                             | 1   |
| fragment:peppo-card-grid                          | 1   |
| fragment:peppo-card-collection                    | 1   |
| fragment:peppo-card-base                          | 1   |
| fragment:front-page-news-bulletin                 | 1   |
| fragment:front-page-features                      | 1   |
| fragment:front-page-artist-showcase               | 1   |
| fragment:card-slot                                | 1   |
| fragment:card                                     | 1   |
| fragment:antho-card-x                             | 1   |
| fragment:antho-card                               | 1   |
| component:redzone-advisory                        | 1   |
| component:peppo-log                               | 1   |
| component:peppo-card-structure                    | 1   |
| component:parawatch-forum-post                    | 1   |
| component:oct-r3                                  | 1   |
| component:interwiki-style                         | 1   |
| component:acs-horm-lite-source                    | 1   |
| :topia:sp-header                                  | 1   |
| :topia:cqb:page-info-slider                       | 1   |
| :topia:component:anomaly-class-numero-bar         | 1   |
| :smlt:component:aers:classification-stuff         | 1   |
| :scpko:theme:anniversary                          | 1   |
| :scpko:component:raisa-ribbon                     | 1   |
| :scpko:component:image-block-peppo                | 1   |
| :scp-wiki:nav:interwiki                           | 1   |
| :scp-wiki:fragment:jerden                         | 1   |
| :scp-wiki:fragment:front-page-header              | 1   |
| :scp-wiki:fragment:front-page-artist-showcase     | 1   |
| :scp-wiki:fragment:facilities-map-legend          | 1   |
| :scp-wiki:fragment:antho-card                     | 1   |
| :scp-wiki:component:svgheader-backend             | 1   |
| :scp-wiki:component:s7-apcs-base                  | 1   |
| :scp-wiki:component:redzone-advisory-base         | 1   |
| :scp-wiki:component:flops-header-source           | 1   |
| :scp-wiki:component:doc-transcript-swapper-deep   | 1   |
| :scp-wiki:component:classified-decoration-base    | 1   |
| :scp-wiki:component:classified-bar-woed-source    | 1   |
| :scp-wiki:component:author-page-collab            | 1   |
| :scp-wiki: component:bhl-dark-sidebar             | 1   |
| :scp-wiki.wikidot.com:component:author-page       | 1   |
| :scp-wiki-cn:component:earthworm                  | 1   |
| :scp-sandbox-3:component:minimap                  | 1   |
| :scp-sandbox-3:component:login-module-base        | 1   |
| :scp-jp:component:image-block                     | 1   |
| :scp-jp.wikidot.com:component:jstyles             | 1   |
| :scp-int:component:img-descr-base                 | 1   |
| :lafundacionscp:component:kochi                   | 1   |
| :kontainer.djkakt.us:scpf-gd-theme                | 1   |
| :kontainer.djkakt.us:ids-authortheme              | 1   |
| :crom:wiki-search                                 | 1   |
| :crom:tag-search                                  | 1   |
</details>